### PR TITLE
change username taken error mesage in en-US

### DIFF
--- a/public/language/en-US/error.json
+++ b/public/language/en-US/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+    "username-taken": "The username is already taken. Try octocat_ci3715.",
     "email-taken": "Email address is already taken.",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",


### PR DESCRIPTION
This pull request resolves issue #1 in the repository /USB-CI3715/NodeBB-Lab2 by changing the username taken error message in spanish (es) to "Nombre de usuario ya en uso. Pruebe utilizando octocat_ci3715.", and in english (en-US) to "The username is already taken. Try octocat_ci3715."
![image](https://github.com/user-attachments/assets/a90ebd35-5a3c-4eb1-bc1c-06abfc7985b9)

